### PR TITLE
Add game reset endpoint

### DIFF
--- a/app/Http/Controllers/API/GameController.php
+++ b/app/Http/Controllers/API/GameController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Game;
+use App\Models\Grid;
+
+class GameController extends Controller
+{
+    /**
+     * Reset a minesweeper game by clearing the grid and placing new mines.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $gameId
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function reset(Request $request, $gameId)
+    {
+        $game = Game::find($gameId);
+
+        if (!$game) {
+            return response()->json(['message' => 'Game not found'], 404);
+        }
+
+        // Remove previous grid
+        Grid::where('game_id', $game->id)->delete();
+
+        // Reset game fields
+        $game->status = 'OPEN';
+        $game->start_at = now();
+        $game->end_at = null;
+        $game->save();
+
+        // Recreate grid with new random mines
+        generateGrid($game->rows, $game->columns, $game->mines, $game->id);
+
+        return response()->json(['message' => 'Game reset successfully'], 200);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,3 +25,6 @@ Route::group([
 });
 
 /** **/
+use App\Http\Controllers\API\GameController;
+
+Route::post('game/{game}/reset', [GameController::class, 'reset']);


### PR DESCRIPTION
## Summary
- create API `GameController` with `reset` method
- add route to reset a game

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c6a5b94688332bcd16c76f5f78ef0